### PR TITLE
Add monthly downloads badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,9 @@ Amply
      :target: https://pypi.org/project/amply/
 .. image:: https://coveralls.io/repos/github/willu47/amply/badge.svg?branch=master
     :target: https://coveralls.io/github/willu47/amply?branch=master
-
+.. image:: https://assets.piptrends.com/get-last-month-downloads-badge/amply.svg
+    :alt: amply Downloads Last Month by pip Trends
+    :target: https://piptrends.com/package/amply
 
 Introduction
 ------------


### PR DESCRIPTION
This PR is to add a monthly downloads badge we have been working on at pip Trends, a learning forum for all python developers. This PR is only to share the badge we have built and if needed the external link from the badge to amply's page on pip Trends can be removed. View more at - https://piptrends.com/package/amply